### PR TITLE
Fix payment popup credit type handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -4221,14 +4221,14 @@ class PaymentHandler {
         }
     }
 
-    openPaymentPopup(snapToken, credits) {
+    openPaymentPopup(snapToken, credits, creditType) {
         console.log('Opening Midtrans popup with token:', snapToken);
-        
+
         window.snap.pay(snapToken, {
             onSuccess: async (result) => {
                 console.log('Payment success:', result);
                 showSuccess('Payment Successful!');
-                await this.handlePaymentSuccess(credits);
+                await this.handlePaymentSuccess(credits, creditType);
             },
             onPending: (result) => {
                 console.log('Payment pending:', result);


### PR DESCRIPTION
## Summary
- pass `creditType` to payment popup
- ensure `handlePaymentSuccess` receives the credit type

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f75aaa6b483288cc3559a764ed260